### PR TITLE
Added support for @tei:style

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "ceteicean"
   ],
   "dependencies": {
+    "cssjson": "^2.1.3",
     "tiny-warning": "^1.0.3"
   },
   "scripts": {

--- a/src/TEINode.js
+++ b/src/TEINode.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import TEIRoutes from './TEIRoutes'
+import { toJSON } from 'cssjson'
 
 class TEINodes extends React.Component {
   render() {
@@ -16,7 +17,16 @@ class TEINodes extends React.Component {
 class TEINode extends React.Component {
   forwardTeiAttributes() {
     return Array.from(this.props.teiNode.attributes).reduce((acc, att) => {
-      acc[att.name === 'ref' ? 'Ref' : att.name] = att.value
+      switch (att.name) {
+        case 'ref':
+          acc['Ref'] = att.value
+          break
+        case 'style':
+          acc['style'] = toJSON(att.value)
+          break
+        default:
+          acc[att.name] = att.value
+      }
       return acc
     }, {})
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1148,6 +1148,11 @@ core-js-compat@^3.6.2, core-js-compat@^3.9.1:
     browserslist "^4.16.4"
     semver "7.0.0"
 
+cssjson@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/cssjson/-/cssjson-2.1.3.tgz#b855aa06c5979df16bf6375a14a455e415660169"
+  integrity sha1-uFWqBsWXnfFr9jdaFKRV5BVmAWk=
+
 debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz"


### PR DESCRIPTION
The `@style` attribute available on many TEI elements was causing an error because it's a restricted React attribute. I've added a way to pass it through and to process its content as CSS.

Let me know what you think -- if this looks good let's push a new release to NPM?