### PR TITLE
Added route for text nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,8 @@ const Reference = (props) => {
   )
 }
 ```
+It is also possible to specify a route to match text nodes using the keyword `text()`:
+
+```JSX
+<TEIRoute el='text()' component={TextNodeHandler}/>
+```

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ const Reference = (props) => {
   )
 }
 ```
+
 It is also possible to specify a route to match text nodes using the keyword `text()`:
 
 ```JSX

--- a/examples/ceteicean.js
+++ b/examples/ceteicean.js
@@ -11,6 +11,42 @@ const teiToHtml = async (file) => {
   return ct.getHTML5(file)
 }
 
+const isWithinSpan = (node, spanName, anchor) => {
+  let currentAnchor = anchor
+  if (node.nodeType === 1) {
+    const el = node
+    // keep track of anchor ids
+    currentAnchor = el.tagName.toLowerCase() === 'tei-anchor' ? el.getAttribute('id') : currentAnchor
+    if (el.tagName.toLowerCase() === spanName.toLowerCase()) {
+      const spanTo = el.getAttribute('spanTo')
+      // if it's the span element, make sure its target anchor hasn't been met yet.
+      if (spanTo) {
+        if (spanTo.replace('#', '') !== currentAnchor) {
+          return true
+        }
+      }
+    } 
+  }
+
+  // recurse if the span hasn't been located yet.
+  const prev = node.previousSibling || node.parentNode
+  if (prev) {
+    return isWithinSpan(prev, spanName, currentAnchor)
+  }
+
+  return false
+}
+
+const TextNode = (props) => {
+  const isDeleted = isWithinSpan(props.teiNode, 'tei-delSpan')
+  if (isDeleted) {
+    return <span style={{textDecoration: 'line-through'}}>
+      {props.teiNode.nodeValue}
+    </span>
+  }
+  return <>{props.teiNode.nodeValue}</>
+}
+
 const Head = (props) => { 
   return (
     <div style={{
@@ -27,7 +63,7 @@ class App extends React.Component {
   }
 
   async componentDidMount() {
-    const teiData = await teiToHtml(`https://raw.githubusercontent.com/TEIC/CETEIcean/master/test/testTEI.xml`)
+    const teiData = await teiToHtml(`./testTEI.xml`)
     this.setState({
       teiData
     })
@@ -41,6 +77,7 @@ class App extends React.Component {
     return (
       <TEIRender data={this.state.teiData}>
         <TEIRoute el="tei-head" component={Head}/>
+        <TEIRoute el="text()" component={TextNode}/>
       </TEIRender>
     )
   }

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>react-teirouter example with CETEIcean</title>
+    <link rel="stylesheet" href="https://gitcdn.link/repo/TEIC/CETEIcean/master/test/CETEIcean.css">
   </head>
   <body>
     <div id="root"/>

--- a/examples/testTEI.xml
+++ b/examples/testTEI.xml
@@ -1,0 +1,76 @@
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Review: an electronic transcription</title>
+      </titleStmt>
+      <publicationStmt>
+        <p>Published as an example for the Introduction module of TBE.</p>
+      </publicationStmt>
+      <sourceDesc>
+        <p>No source: born digital.</p>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <tagsDecl>
+        <rendition scheme="css" xml:id="italic">font-style: italic;</rendition>
+        <rendition scheme="css" selector="title">text-decoration: underline;</rendition>
+      </tagsDecl>
+    </encodingDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <head>Review</head>
+      <p>
+        <title xml:id="foo" xml:lang="de">Die Leiden des jungen Werther</title>
+        <note place="end">by <name>Goethe</name></note>
+        is an <emph>exceptionally</emph>
+        good example of a book full of <term rendition="#italic">Weltschmerz</term>.
+        Here is some <add>added</add> text.</p>
+      <p>Here is a pointer: <ptr target="https://github.com/TEIC/CETEIcean"/>.
+    And here is a <ref target="https://github.com/TEIC">ref</ref>. But
+    <ref target="addBehaviorTest.html">here</ref> is a relative link.</p>
+    <p><egXML xmlns="http://www.tei-c.org/ns/Examples"><fuzzbuckets>egXML test</fuzzbuckets></egXML></p>
+    <table rows="4" cols="4">
+      <head>Poor Man's Lodgings in Norfolk (Mayhew, 1843)</head>
+      <row role="label">
+        <cell/>
+        <cell>Dossing Cribs or Lodging Houses</cell>
+        <cell>Beds</cell>
+        <cell>Needys or Nightly Lodgers</cell>
+      </row>
+      <row>
+        <cell role="label">Bury St Edmund's</cell>
+        <cell>5</cell>
+        <cell>8</cell>
+        <cell>128</cell>
+      </row>
+      <row>
+        <cell role="label">Thetford</cell>
+        <cell>3</cell>
+        <cell>6</cell>
+        <cell>36</cell>
+      </row>
+      <row>
+        <cell role="label" cols="2">Attleboro'<note place="end">The borough of Attle.</note></cell>
+        <cell>5</cell>
+        <cell>20</cell>
+      </row>
+      <row>
+        <cell role="label">Wymondham</cell>
+        <cell>1</cell>
+        <cell>11</cell>
+        <cell>22</cell>
+      </row>
+      </table>
+
+      <p>Delspan test</p>
+      <delSpan spanTo="#D1"/>
+      <list>
+        <item>item one</item>
+        <item>item <anchor xml:id="D1"/> two</item>
+      </list>
+
+    </body>
+  </text>
+</TEI>

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "CETEIcean": "^1.2.1",
     "react": "17.0.2",
     "react-dom": "^17.0.2",
-    "rollup": "^2.18.2",
+    "rollup": "2.56.2",
     "rollup-plugin-copy": "^3.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "react-teirouter",
-<<<<<<< HEAD
   "version": "2.1.0",
-=======
-  "version": "2.0.5",
->>>>>>> a7bf8f61a6f01afa0638bba60da8e018c0d985bd
   "description": "TEI for React",
   "author": "pfefferniels <niels.pfeffer@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-teirouter",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "TEI for React",
   "author": "pfefferniels <niels.pfeffer@gmail.com>",
   "license": "MIT",

--- a/rollup-examples.config.js
+++ b/rollup-examples.config.js
@@ -34,7 +34,8 @@ export default {
     commonjs(),
     copy({
       targets: [
-        { src: 'examples/index.html', dest: 'dist/public' }
+        { src: 'examples/index.html', dest: 'dist/public' },
+        { src: 'examples/testTEI.xml', dest: 'dist/public' }
       ]
     }),
   ]

--- a/src/TEINode.js
+++ b/src/TEINode.js
@@ -35,6 +35,24 @@ class TEINode extends React.Component {
     if (!this.props.teiNode) return null
 
     if (this.props.teiNode.nodeType === 3) {
+      if (this.props.availableRoutes.includes('text()')) {
+        const propsClone = {
+          ...this.props,
+          teiNode: this.props.teiNode
+        }
+        return (
+          <TEIRoutes.Consumer>
+            {(routes) => {
+              const selectedRoute = routes['text()']
+              if (React.isValidElement(selectedRoute)) {
+                return React.cloneElement(selectedRoute, {...propsClone},)
+              }
+  
+              return React.createElement(selectedRoute, propsClone)
+            }}
+          </TEIRoutes.Consumer>
+        )
+      }
       return this.props.teiNode.nodeValue
     }
 

--- a/src/TEINode.js
+++ b/src/TEINode.js
@@ -33,67 +33,55 @@ class TEINode extends React.Component {
 
   render() {
     if (!this.props.teiNode) return null
-        
+
+    let matchName
+    let teiChildren
+
+    // Return an element if this is a text node and there is a text() route
+    // or if a route matches the current element node's tagname.
     if (this.props.teiNode.nodeType === 3) {
       if (this.props.availableRoutes.includes('text()')) {
-        const propsClone = {
-          ...this.props,
-          teiNode: this.props.teiNode
-        }
-        return (
-          <TEIRoutes.Consumer>
-            {(routes) => {
-              const selectedRoute = routes['text()']
-              if (React.isValidElement(selectedRoute)) {
-                return React.cloneElement(selectedRoute, {...propsClone},)
-              }
-  
-              return React.createElement(selectedRoute, propsClone)
-            }}
-          </TEIRoutes.Consumer>
-        )
+        matchName = 'text()'
+      } else {
+        return this.props.teiNode.nodeValue
       }
-      return this.props.teiNode.nodeValue
-    }
-    
-    if (this.props.teiNode.nodeType !== 1) return null
+    } else if (this.props.teiNode.nodeType === 1) {
+      const el = this.props.teiNode
+      const tagName = el.tagName.toLowerCase()
+      teiChildren = <TEINodes teiNodes={el.childNodes} {...this.props} />
 
-    const el = this.props.teiNode
-    const tagName = el.tagName.toLowerCase()
-
-    const teiChildren = <TEINodes teiNodes={el.childNodes} {...this.props} />
-
-    if (this.props.availableRoutes.includes(tagName)) {
-      const propsClone = {
-        ...this.props,
-        teiNode: el
+      if (this.props.availableRoutes.includes(tagName)) {
+        matchName = tagName
+      } else {
+        // Return unchanged element.
+        return React.createElement(tagName,
+          {...this.forwardTeiAttributes()},
+          teiChildren)
       }
-
-      return (
-        <TEIRoutes.Consumer>
-          {(routes) => {
-            const selectedRoute = routes[tagName]
-
-            // Routes can be given as child elements that are
-            // created already and need to be cloned here,
-            // or as a component, that is not yet instantiated.
-            if (React.isValidElement(selectedRoute)) {
-              return React.cloneElement(selectedRoute,
-                                        {...propsClone},
-                                        teiChildren)
-            }
-
-            return React.createElement(selectedRoute,
-                                       propsClone,
-                                       teiChildren)
-          }}
-        </TEIRoutes.Consumer>
-      )
+    } else {
+      return null
     }
 
-    return React.createElement(tagName,
-                               {...this.forwardTeiAttributes()},
-                               teiChildren)
+    return (
+      <TEIRoutes.Consumer>
+        {(routes) => {
+          const selectedRoute = routes[matchName]
+
+          // Routes can be given as child elements that are
+          // created already and need to be cloned here,
+          // or as a component, that is not yet instantiated.
+          if (React.isValidElement(selectedRoute)) {
+            return React.cloneElement(selectedRoute,
+                                      {...this.props},
+                                      teiChildren)
+          }
+
+          return React.createElement(selectedRoute,
+                                      {...this.props},
+                                      teiChildren)
+        }}
+      </TEIRoutes.Consumer>
+    )
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1249,10 +1249,10 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@~2.1.2:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
-  integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+fsevents@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -1616,12 +1616,12 @@ rollup-plugin-copy@^3.4.0:
     globby "10.0.1"
     is-plain-object "^3.0.0"
 
-rollup@^2.18.2:
-  version "2.18.2"
-  resolved "https://registry.npmjs.org/rollup/-/rollup-2.18.2.tgz"
-  integrity sha512-+mzyZhL9ZyLB3eHBISxRNTep9Z2qCuwXzAYkUbFyz7yNKaKH03MFKeiGOS1nv2uvPgDb4ASKv+FiS5mC4h5IFQ==
+rollup@2.56.2:
+  version "2.56.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.56.2.tgz#a045ff3f6af53ee009b5f5016ca3da0329e5470f"
+  integrity sha512-s8H00ZsRi29M2/lGdm1u8DJpJ9ML8SUOpVVBd33XNeEeL3NVaTiUcSBHzBdF3eAyR0l7VSpsuoVUGrRHq7aPwQ==
   optionalDependencies:
-    fsevents "~2.1.2"
+    fsevents "~2.3.2"
 
 run-parallel@^1.1.9:
   version "1.2.0"


### PR DESCRIPTION
Added a route option for text nodes, in case users want to process text nodes directly. This can be useful to support spanning elements like `<delSpan>` that may affect text nodes, e.g.:

```xml
<delSpan spanTo="#D1"/>
<list>
    <item>item one</item>
    <item>item <anchor xml:id="D1"/> two</item>
</list>
```

Where the text node with value "item" is affected, while its sibling "two" is not. By writing a component that matches text nodes, one can determine which text node is deleted and which isn't and, for example, apply styles.

I chose the keyword `text()` to match text nodes, as it will be familiar to XPath users, but I'm open to other suggestions.