### PR TITLE
Allowed React 18 peer dependency. Upped version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-teirouter",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "TEI for React",
   "author": "pfefferniels <niels.pfeffer@gmail.com>",
   "license": "MIT",
@@ -23,7 +23,7 @@
     "examples": "rollup --config rollup-examples.config.js"
   },
   "peerDependencies": {
-    "react": "^17.0.2"
+    "react": "^17.0.2 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.10.4",


### PR DESCRIPTION
This avoids peer-dependency warnings when trying to use with React 18. Tested with a project that I recently upgraded to React 18 and it works fine.

If merged, please make a release on npm, thank you!